### PR TITLE
Powrap true

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -37,6 +37,7 @@ jobs:
         venv/bin/pip --version
         venv/bin/tx --version
         venv/bin/sphinx-intl --help
+        venv/bin/powrap --version
 
     - name: If failed, make the log file an artifact
       if: failure()

--- a/Makefile
+++ b/Makefile
@@ -86,7 +86,7 @@ push:
 .PHONY: pull
 pull: venv
 	$(VENV)/bin/tx pull --force --language=$(LANGUAGE) --parallel
-	$(VENV)/bin/powrap --quiet *.po **/*.po
+	$(VENV)/bin/powrap --quiet *.po **/*.po || true
 
 
 # tx-config: After running "pot", create a new Transifex config file by


### PR DESCRIPTION
_powrap_ encerra com status 1 quando algum arquivo foi modificado com sucesso, encerrando o Make como erro. Relatei em https://github.com/JulienPalard/powrap/issues/19.

Este PR contorna este problema anexando `|| true` ao powrap, ainda que temporariamente. Também adiciona, ao workflow, a impressão da versão do powrap na fase de preparação do ambiente.