### PR TITLE
workflow: do not run on forks

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -8,6 +8,8 @@ on:
 jobs:
   build:
 
+    if: (github.event_name == 'schedule' && github.repository == 'python/python-docs-pt-br') || (github.event_name != 'schedule')
+
     runs-on: ubuntu-latest
     strategy:
       max-parallel: 4


### PR DESCRIPTION
Atualmente, o agendamento diário do GitHub Actions é executado nos forks deste repositório, sempre falhando em fazer o "commit" por falta de permissão (o que é bom!).  Este commit adiciona uma condição que simplesmente não executa nada caso o repositório não seja python/python-docs-pt-br, excluindo assim os forks.

Citando a [fonte da solução](https://github.community/t5/GitHub-Actions/Do-not-run-cron-workflows-in-forks/td-p/46756):
> This workflow will execute the job **_build_** only when meeting one of the following situations:
> 1) The event is **_schedule_** and the repository is _**main_org/main_repo**_, if the repository is not **_main_org/main_repo_** the job **_build_** will be skipped.
> 2) The event is not _**schedule**_ and the repository can be anyone.

(main_org/main_repo, neste caso, é python/python-docs-pt-br)