### PR TITLE
Improve Makefile and workflow

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -1,4 +1,4 @@
-name: python-docs-pt-br CI
+name: Build and update documentation
 
 # Daily at 0 am
 #on:

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -13,8 +13,6 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       max-parallel: 4
-      matrix:
-        python-version: [3.7]
 
     steps:
     - uses: actions/checkout@v2
@@ -24,9 +22,7 @@ jobs:
         git fetch --no-tags --prune --depth=1 origin +refs/heads/*:refs/remotes/origin/*
 
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v1
-      with:
-        python-version: ${{ matrix.python-version }}
+      uses: actions/setup-python@v2
 
     - name: Install dependencies via package manager
       run: |
@@ -45,7 +41,7 @@ jobs:
 
     - name: If failed, make the log file an artifact
       if: failure()
-      uses: actions/upload-artifact@v1
+      uses: actions/upload-artifact@v2
       with:
         name: pip-install-log
         path: venv/pip-install.log

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -1,13 +1,19 @@
-name: Build and update documentation
+name: python-docs-pt-br CI
 
 # Daily at 0 am
-on:
-  schedule:
-    - cron: '0 0 * * *'
+#on:
+#  schedule:
+#    - cron: '0 0 * * *'
+on: push
+
+# Branch where translation takes place
+env:
+  BRANCH: 3.8
 
 jobs:
-  build:
 
+  # Job to pull, build and push translations from Transifex to the repository
+  update:
     if: (github.event_name == 'schedule' && github.repository == 'python/python-docs-pt-br') || (github.event_name != 'schedule')
 
     runs-on: ubuntu-latest
@@ -17,40 +23,14 @@ jobs:
     steps:
     - uses: actions/checkout@v2
       with:
-        ref: 3.8
-    - run: |
-        git fetch --no-tags --prune --depth=1 origin +refs/heads/*:refs/remotes/origin/*
+        ref: ${{ env.BRANCH }}
 
-    - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
+    - uses: actions/setup-python@v2
+    - run: sudo apt update
+    - run: sudo apt install -y gettext
+    - run: make tx-config
 
-    - name: Install dependencies via package manager
-      run: |
-        sudo apt update
-        sudo apt install -y gettext hunspell hunspell-pt-br
-        msgfmt -V
-        hunspell -v
-
-    - name: Prepare virtual environment
-      run: |
-        make venv
-        venv/bin/pip --version
-        venv/bin/tx --version
-        venv/bin/sphinx-intl --help
-        venv/bin/powrap --version
-
-    - name: If failed, make the log file an artifact
-      if: failure()
-      uses: actions/upload-artifact@v2
-      with:
-        name: pip-install-log
-        path: venv/pip-install.log
-
-    - name: Recreate an up-to-date project .tx/config
-      run: |
-        make tx-config
-
-    - name: Update translations from Transifex
+    - name: Run make pull
       run: |
         if [[ -n "$TRANSIFEX_APIKEY" ]]; then
             echo -e "[https://www.transifex.com]\n"          \
@@ -65,11 +45,9 @@ jobs:
       env:
           TRANSIFEX_APIKEY: ${{ secrets.TRANSIFEX_APIKEY }}
 
-    - name: Build documentation
-      run: |
-        make build CPYTHON_PATH=/tmp/cpython/ SPHINXERRORHANDLING=''
+    - run: make build CPYTHON_PATH=/tmp/cpython/ SPHINXERRORHANDLING=''
 
-    - name: Push translations
+    - name: Run make push
       run: |
         git config user.email "github-actions[bot]@users.noreply.github.com"
         git config user.name "github-actions[bot]"
@@ -77,23 +55,79 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-    - name: Check spelling of translations
+  # Job to check spelling of translations
+  spellcheck:
+    needs: update
+    runs-on: ubuntu-latest
+    strategy:
+      max-parallel: 4
+
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        ref: ${{ env.BRANCH }}
+
+    - uses: actions/setup-python@v2
+    - run: sudo apt update
+    - run: sudo apt install -y gettext hunspell hunspell-pt-br
+
+    - name: Run make spell
       run: |
         make spell
         cd .pospell/
         tar -czf ../pospell-out.tar.gz *.txt **/*.txt
 
-    - name: Make spellchecking output available
-      uses: actions/upload-artifact@v1
+    - name: Update artifact spellchecking-output
+      uses: actions/upload-artifact@v2
       with:
         name: spellchecking-output
         path: pospell-out.tar.gz
 
-    - name: Merge translations with older branches
-      run: make merge
+  # Job to merge translation from current BRANCH to older ones
+  merge:
+    needs: update
+    runs-on: ubuntu-latest
+    strategy:
+      max-parallel: 4
+
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        ref: ${{ env.BRANCH }}
+
+    - run: |
+        git fetch --no-tags --prune --depth=1 origin +refs/heads/*:refs/remotes/origin/*
+
+    - uses: actions/setup-python@v2
+    - run: sudo apt update
+    - run: sudo apt install -y gettext
+
+    - name: Run make push
+      run: |
+        git config user.email "github-actions[bot]@users.noreply.github.com"
+        git config user.name "github-actions[bot]"
+        make merge
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-    - name: Build documentation treating warnings as errors
-      run: |
-        make build CPYTHON_PATH=/tmp/cpython/
+  # Job to build translated documentation treating warnings as errors
+  build-warn-as-err:
+    needs: update
+    runs-on: ubuntu-latest
+    strategy:
+      max-parallel: 4
+
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        ref: ${{ env.BRANCH }}
+
+    - uses: actions/setup-python@v2
+    - run: make build CPYTHON_PATH=/tmp/cpython/ 2> >(tee -a build-log.txt >&2)
+
+    - name: Update artifact spellchecking-output
+      if: ${{ failure() }}
+      uses: actions/upload-artifact@v2
+      with:
+        name: build-output
+        path: build-log.txt

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -93,6 +93,11 @@ jobs:
         name: spellchecking-output
         path: pospell-out.tar.gz
 
+    - name: Merge translations with older branches
+      run: make merge
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
     - name: Build documentation treating warnings as errors
       run: |
         make build CPYTHON_PATH=/tmp/cpython/

--- a/Makefile
+++ b/Makefile
@@ -79,9 +79,9 @@ build: setup
 		  "or run 'make serve' to see them in http://localhost:8000";
 
 
-# push: push new translation files and Transifex config files to repository,
-#       if any. Do nothing if there is no file changes. If GITHUB_TOKEN is set,
-#       then assumes we are in GitHub Actions, requiring different push args
+# push: push changed translation files and Transifex config file to repository.
+#       Do nothing if there is no file changes. If GITHUB_TOKEN is set, then
+#       assumes we are in GitHub Actions, requiring different push args.
 .PHONY: push
 push:
 	@if ! git status -s | egrep '\.po|\.tx/config'; then                    \
@@ -109,8 +109,7 @@ pull: venv
 
 
 # tx-config: After running "pot", create a new Transifex config file by
-#            reading pot files generated, then tweak this config file to
-#            LANGUAGE.
+#            reading pot files generated, then tweak it to LANGUAGE.
 .PHONY: tx-config
 tx-config: TRANSIFEX_PROJECT := python-newest
 tx-config: pot
@@ -131,7 +130,7 @@ tx-config: pot
 
 
 # pot: After running "setup" target, run a cpython Makefile's target
-#      to generate .pot files under $(CPYTHON_WORKDIR)/Doc/locales/pot
+#      to generate .pot files under $(CPYTHON_WORKDIR)/Doc/locales/pot.
 .PHONY: pot
 pot: setup
 	@$(MAKE) -C $(CPYTHON_WORKDIR)/Doc/         \
@@ -178,7 +177,7 @@ setup: venv
 
 
 # venv: create a virtual environment which will be used by almost every
-#       other target of this script
+#       other target of this script.
 .PHONY: venv
 venv:
 	@if [ ! -d $(VENV) ]; then                                         \
@@ -199,7 +198,7 @@ serve:
 # spell: run spell checking tool in all po files listed in SRCS variable,
 #        storing the output in text files DESTS for proofreading.  The
 #        DESTS target run the spellchecking, while the typos.txt target
-#        gather all reported issues in one file, sorted without redundancy
+#        gather all reported issues in one file, sorted without redundancy.
 .PHONY: spell
 
 SRCS := $(wildcard *.po **/*.po)
@@ -239,8 +238,8 @@ $(MERGEBRANCHES):
 	@git checkout $(BRANCH)
 
 
-# clean: remove all .mo files and the venv directory that may exist and
-#        could have been created by the actions in other targets of this script
+# clean: remove all .mo files and the venv directory that may exist and could
+#        have been created by the actions in other targets of this script.
 .PHONY: clean
 clean:
 	rm -fr $(VENV)

--- a/Makefile
+++ b/Makefile
@@ -166,16 +166,12 @@ setup: venv
 #       other target of this script
 .PHONY: venv
 venv:
-	@echo "Setting up $(LANGUAGE_TEAM)'s virtual environment ...";
-	@if [ ! -d $(VENV) ]; then                                           \
-		$(PYTHON) -m venv --prompt $(LANGUAGE_TEAM) $(VENV);             \
+	@if [ ! -d $(VENV) ]; then                                         \
+	    echo "Setting up $(LANGUAGE_TEAM)'s virtual environment ...";  \
+	    $(PYTHON) -m venv --prompt $(LANGUAGE_TEAM) $(VENV);           \
+	    $(VENV)/bin/python -m pip install --upgrade pip;               \
 	fi
-	
-	@$(VENV)/bin/python -m pip install -q -r requirements.txt 2> $(VENV)/pip-install.log
-	
-	@if grep -q 'pip install --upgrade pip' $(VENV)/pip-install.log; then \
-		$(VENV)/bin/pip install -q --upgrade pip;                         \
-	fi
+	@$(VENV)/bin/pip install --upgrade --requirement requirements.txt
 
 
 # serve: serve the documentation in a simple local web server, using cpython

--- a/Makefile
+++ b/Makefile
@@ -5,27 +5,41 @@
 #  based on: https://github.com/python/python-docs-fr/blob/3.8/Makefile
 #
 
+#################
 # Configuration
 
-CPYTHON_PATH        := ../cpython
-BRANCH              := 3.8
+# Main translation branch; please make sure it matches 'python-newest'
+# project's version in 'python-docs' organization in Transifex
+BRANCH              := $(shell git branch --show-current)
+
+# Branches representing docs for older Python versions, which current
+# translations should be merged into
 MERGEBRANCHES       := 3.7 3.6 2.7
+
+# Name of language team; should be python-docs-LANG, where LANG is the
+# IETF language tag for your language; see Language Tag section in PEP 545
 LANGUAGE_TEAM       := python-docs-pt-br
+
+# Language code in ISO 639; see Language Tag section in PEP 545, and
+# Sphinx configuration's supported languages
 LANGUAGE            := pt_BR
 
-# Internal variables
-
+# Paths and URLs
 UPSTREAM            := https://github.com/python/cpython
-VENV                := $(shell realpath ./venv)
 PYTHON              := $(shell which python3)
+CPYTHON_PATH        := $(shell realpath ../cpython)
+POSPELL_TMP_DIR     := .pospell
+VENV                := $(shell realpath ./venv)
 WORKDIRS            := $(VENV)/workdirs
 CPYTHON_WORKDIR     := $(WORKDIRS)/cpython
 LOCALE_DIR          := $(WORKDIRS)/locale
+
+# Settings for 'build' target
 JOBS                := auto
 SPHINXERRORHANDLING := "-W"
-TRANSIFEX_PROJECT   := python-newest
-POSPELL_TMP_DIR     := .pospell
 
+#
+#################
 
 .PHONY: help
 help:
@@ -98,6 +112,7 @@ pull: venv
 #            reading pot files generated, then tweak this config file to
 #            LANGUAGE.
 .PHONY: tx-config
+tx-config: TRANSIFEX_PROJECT := python-newest
 tx-config: pot
 	@cd $(CPYTHON_WORKDIR)/Doc/locales;                 \
 	rm -rf .tx;                                         \
@@ -181,16 +196,15 @@ serve:
 	@$(MAKE) -C $(CPYTHON_WORKDIR)/Doc serve
 
 
-# list files for spellchecking
-SRCS := $(wildcard *.po **/*.po)
-DESTS = $(addprefix $(POSPELL_TMP_DIR)/out/,$(patsubst %.po,%.txt,$(SRCS)))
-
-
 # spell: run spell checking tool in all po files listed in SRCS variable,
 #        storing the output in text files DESTS for proofreading.  The
 #        DESTS target run the spellchecking, while the typos.txt target
 #        gather all reported issues in one file, sorted without redundancy
 .PHONY: spell
+
+SRCS := $(wildcard *.po **/*.po)
+DESTS = $(addprefix $(POSPELL_TMP_DIR)/out/,$(patsubst %.po,%.txt,$(SRCS)))
+
 spell: venv $(DESTS) $(POSPELL_TMP_DIR)/typos.txt
 
 $(POSPELL_TMP_DIR)/out/%.txt: %.po dict

--- a/Makefile
+++ b/Makefile
@@ -76,7 +76,7 @@ build: setup
 		html
 		
 	@echo "Success! Open file://$(CPYTHON_WORKDIR)/Doc/build/html/index.html, " \
-		  "or run 'make serve' to see them in http://localhost:8000";
+	      "or run 'make serve' to see them in http://localhost:8000";
 
 
 # push: push changed translation files and Transifex config file to repository.
@@ -151,9 +151,11 @@ pot: setup
 setup: venv
 	@if ! [ -d $(CPYTHON_PATH) ]; then                                      \
 		echo "CPython repo not found; cloning ...";                         \
-		git clone --depth 1 --branch $(BRANCH) $(UPSTREAM) $(CPYTHON_PATH); \
+		git clone --depth 1 --no-single-branch $(UPSTREAM) $(CPYTHON_PATH); \
+		git -C $(CPYTHON_PATH) checkout $(BRANCH);                          \
 	else                                                                    \
 		echo "CPython repo found; updating ...";                            \
+		git -C $(CPYTHON_PATH) checkout $(BRANCH);                          \
 		git -C $(CPYTHON_PATH) pull --rebase;                               \
 	fi
 	
@@ -166,7 +168,7 @@ setup: venv
 			VENVDIR=$(CPYTHON_WORKDIR)/Doc/venv                             \
 			PYTHON=$(PYTHON) venv;                                          \
 	else                                                                    \
-	    echo "CPython repo already ready in workdir";                       \
+		echo "CPython repo already ready in workdir";                       \
 	fi
 	
 	@echo "Setting up translation files in workdir ..."

--- a/Makefile
+++ b/Makefile
@@ -106,13 +106,12 @@ tx-config: pot
 	    --locale-dir .                                  \
 	    --pot-dir pot;
 	
-	cd $(OLDPWD)
-	mv $(CPYTHON_WORKDIR)/Doc/locales/.tx/config .tx/config
-	
-	sed -i .tx/config                                 \
+	mkdir -p .tx
+	sed $(CPYTHON_WORKDIR)/Doc/locales/.tx/config     \
 	    -e '/^source_file/d'                          \
 	    -e 's|<lang>/LC_MESSAGES/||'                  \
-	    -e "s|^file_filter|trans.$(LANGUAGE)|"
+	    -e "s|^file_filter|trans.$(LANGUAGE)|"        \
+	    > .tx/config
 
 
 # pot: After running "setup" target, run a cpython Makefile's target

--- a/library/importlib.po
+++ b/library/importlib.po
@@ -1546,7 +1546,7 @@ msgstr ""
 
 #: ../../library/importlib.rst:1311
 msgid "(``__loader__``)"
-msgstr ""
+msgstr "(``__loader__``)"
 
 #: ../../library/importlib.rst:1313
 msgid ""

--- a/library/stdtypes.po
+++ b/library/stdtypes.po
@@ -10,9 +10,9 @@
 # (Douglas da Silva) <dementikovalev@yandex.ru>, 2017
 # Raphael Mendonça, 2017
 # Claudio Rogerio Carvalho Filho <excriptbrasil@gmail.com>, 2017
-# Rafael Fontenelle <rffontenelle@gmail.com>, 2020
 # Adorilson Bezerra <adorilson@gmail.com>, 2020
 # Vinicius Gubiani Ferreira <vini.g.fer@gmail.com>, 2020
+# Rafael Fontenelle <rffontenelle@gmail.com>, 2020
 #
 #, fuzzy
 msgid ""
@@ -21,7 +21,7 @@ msgstr ""
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2020-03-04 12:51+0000\n"
 "PO-Revision-Date: 2017-02-16 23:27+0000\n"
-"Last-Translator: Vinicius Gubiani Ferreira <vini.g.fer@gmail.com>, 2020\n"
+"Last-Translator: Rafael Fontenelle <rffontenelle@gmail.com>, 2020\n"
 "Language-Team: Portuguese (Brazil) (https://www.transifex.com/python-doc/"
 "teams/5390/pt_BR/)\n"
 "MIME-Version: 1.0\n"
@@ -5701,6 +5701,8 @@ msgid ""
 "Instances of :class:`set` and :class:`frozenset` provide the following "
 "operations:"
 msgstr ""
+"Instâncias de :class:`set` e :class:`frozenset` fornecem as seguintes "
+"operações:"
 
 #: ../../library/stdtypes.rst:4004
 msgid "Return the number of elements in set *s* (cardinality of *s*)."
@@ -5956,6 +5958,10 @@ msgid ""
 "value`` pairs within braces, for example: ``{'jack': 4098, 'sjoerd': 4127}`` "
 "or ``{4098: 'jack', 4127: 'sjoerd'}``, or by the :class:`dict` constructor."
 msgstr ""
+"Dicionários podem ser criados posicionando uma lista de pares ``key: value`` "
+"separados por vírgula dentro de chaves, por exemplo: ``{'jack': 4098, "
+"'sjoerd': 4127}`` ou ``{4098: 'jack', 4127: 'sjoerd'}``, ou usando o "
+"construtor de :class:`dict`."
 
 #: ../../library/stdtypes.rst:4188
 msgid ""
@@ -5991,6 +5997,10 @@ msgid ""
 "being added is already present, the value from the keyword argument replaces "
 "the value from the positional argument."
 msgstr ""
+"Se argumentos nomeados são fornecidos, os argumentos nomeados e seus valores "
+"são adicionados ao dicionário criado a partir do argumento posicional. Se "
+"uma chave sendo adicionada já está presente, o valor do argumento nomeado "
+"substitui o valor do argumento posicional."
 
 #: ../../library/stdtypes.rst:4206
 msgid ""
@@ -6003,6 +6013,9 @@ msgid ""
 "Providing keyword arguments as in the first example only works for keys that "
 "are valid Python identifiers.  Otherwise, any valid keys can be used."
 msgstr ""
+"Fornecer argumentos nomeados conforme no primeiro exemplo somente funciona "
+"para chaves que são identificadores válidos no Python. Caso contrário, "
+"quaisquer chaves válidas podem ser usadas."
 
 #: ../../library/stdtypes.rst:4221
 msgid ""
@@ -6048,6 +6061,9 @@ msgid ""
 "Counter`.  A different ``__missing__`` method is used by :class:`collections."
 "defaultdict`."
 msgstr ""
+"O exemplo acima mostra parte da implementação de :class:`collections."
+"Counter`. Um método ``__missing__`` diferente é usado para :class:"
+"`collections.defaultdict`."
 
 #: ../../library/stdtypes.rst:4263
 msgid "Set ``d[key]`` to *value*."
@@ -6108,6 +6124,9 @@ msgid ""
 "*default* is not given, it defaults to ``None``, so that this method never "
 "raises a :exc:`KeyError`."
 msgstr ""
+"Retorna o valor para *key* se *key* está no dicionário, caso contrário "
+"*default*. Se *default* não é fornecido, será usado o valor padrão ``None``, "
+"de tal forma que este método nunca levanta um :exc:`KeyError`."
 
 #: ../../library/stdtypes.rst:4309
 msgid ""

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ transifex-client
 sphinx-intl
 powrap
 pospell
+pomerge


### PR DESCRIPTION
Makefile:
 - Add `pomerge` to merge translations from 3.8 to older branches
 - Reorganize and add documentation to variables
 - Remove echo of command lines for a cleaner output
 - Fix bug in `tx-config` of incorrect use of OLDPWD variable
 - clone CPython using `--no-single-branch` to allow checkout of other branches

Workflow:
 - use default python version (3.8) by removing `python-version` from `strategy,matrix`
 - update `actions/setup-python` and ` actions/upload-artifact` actions to version 2
 - split all-in-one `build` job into main `update` (most actions) and secondary`_merge`, `spellcheck` and `build-warn-as-err` to reduce the size of the output log and to make it easier to read it
 - rename workflow to `python-docs-pt-br CI`