### PR TITLE
workflow: renable on.schedule event

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -1,10 +1,9 @@
 name: Build and update documentation
 
 # Daily at 0 am
-#on:
-#  schedule:
-#    - cron: '0 0 * * *'
-on: push
+on:
+  schedule:
+    - cron: '0 0 * * *'
 
 # Branch where translation takes place
 env:


### PR DESCRIPTION
I disabled `on.schedule` event for testing and forgot to enable it again.