### PR TITLE
Improve workflow

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -14,21 +14,17 @@ jobs:
   # Job to pull, build and push translations from Transifex to the repository
   update:
     if: (github.event_name == 'schedule' && github.repository == 'python/python-docs-pt-br') || (github.event_name != 'schedule')
-
     runs-on: ubuntu-latest
     strategy:
       max-parallel: 4
-
     steps:
     - uses: actions/checkout@v2
       with:
         ref: ${{ env.BRANCH }}
-
     - uses: actions/setup-python@v2
     - run: sudo apt update
     - run: sudo apt install -y gettext
     - run: make tx-config
-
     - name: Run make pull
       run: |
         if [[ -n "$TRANSIFEX_APIKEY" ]]; then
@@ -43,9 +39,7 @@ jobs:
         git status --short
       env:
           TRANSIFEX_APIKEY: ${{ secrets.TRANSIFEX_APIKEY }}
-
     - run: make build CPYTHON_PATH=/tmp/cpython/ SPHINXERRORHANDLING=''
-
     - name: Run make push
       run: |
         git config user.email "github-actions[bot]@users.noreply.github.com"
@@ -61,22 +55,18 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       max-parallel: 4
-
     steps:
     - uses: actions/checkout@v2
       with:
         ref: ${{ env.BRANCH }}
-
     - uses: actions/setup-python@v2
     - run: sudo apt update
     - run: sudo apt install -y gettext hunspell hunspell-pt-br
-
     - name: Run make spell
       run: |
         make spell
         cd .pospell/
         tar -czf ../pospell-out.tar.gz *.txt **/*.txt
-
     - name: Update artifact spellchecking-output
       uses: actions/upload-artifact@v2
       with:
@@ -90,19 +80,14 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       max-parallel: 4
-
     steps:
     - uses: actions/checkout@v2
       with:
         ref: ${{ env.BRANCH }}
-
-    - run: |
-        git fetch --no-tags --prune --depth=1 origin +refs/heads/*:refs/remotes/origin/*
-
+    - run: git fetch --no-tags --prune --depth=1 origin +refs/heads/*:refs/remotes/origin/*
     - uses: actions/setup-python@v2
     - run: sudo apt update
     - run: sudo apt install -y gettext
-
     - name: Run make push
       run: |
         git config user.email "github-actions[bot]@users.noreply.github.com"
@@ -118,15 +103,12 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       max-parallel: 4
-
     steps:
     - uses: actions/checkout@v2
       with:
         ref: ${{ env.BRANCH }}
-
     - uses: actions/setup-python@v2
     - run: make build CPYTHON_PATH=/tmp/cpython/ 2> >(tee -a build-log.txt >&2)
-
     - name: Update artifact build-output
       if: ${{ failure() }}
       uses: actions/upload-artifact@v2

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -47,6 +47,13 @@ jobs:
         make push
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    - uses: appleboy/telegram-action@master
+      if: ${{ failure() }}
+      with:
+        to: ${{ secrets.TELEGRAM_TO }}
+        token: ${{ secrets.TELEGRAM_TOKEN }}
+        format: markdown
+        args: "❌ Falha na execução do workflow, job&nbsp;*${{ github.job }}* (ID&nbsp;*${{ github.run_id }}*). [Saiba mais sobre o erro...](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }})"
 
   # Job to check spelling of translations
   spellcheck:
@@ -115,3 +122,10 @@ jobs:
       with:
         name: build-output
         path: build-log.txt
+    - uses: appleboy/telegram-action@master
+      if: ${{ failure() }}
+      with:
+        to: ${{ secrets.TELEGRAM_TO }}
+        token: ${{ secrets.TELEGRAM_TOKEN }}
+        format: markdown
+        args: "❌ Falha na execução do workflow, job&nbsp;*${{ github.job }}* (ID&nbsp;*${{ github.run_id }}*). [Saiba mais sobre o erro...](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }})"

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -56,6 +56,7 @@ jobs:
 
   # Job to check spelling of translations
   spellcheck:
+    if: (github.event_name == 'schedule' && github.repository == 'python/python-docs-pt-br') || (github.event_name != 'schedule')
     needs: update
     runs-on: ubuntu-latest
     strategy:
@@ -84,6 +85,7 @@ jobs:
 
   # Job to merge translation from current BRANCH to older ones
   merge:
+    if: (github.event_name == 'schedule' && github.repository == 'python/python-docs-pt-br') || (github.event_name != 'schedule')
     needs: update
     runs-on: ubuntu-latest
     strategy:
@@ -111,6 +113,7 @@ jobs:
 
   # Job to build translated documentation treating warnings as errors
   build-warn-as-err:
+    if: (github.event_name == 'schedule' && github.repository == 'python/python-docs-pt-br') || (github.event_name != 'schedule')
     needs: update
     runs-on: ubuntu-latest
     strategy:


### PR DESCRIPTION
This removes blank lines, and disables secondary jobs as well in forks.

This also adds a Telegram notification with the message like:

> "❌ Falha na execução do workflow, job **update** (ID **142965052**). Saiba mais sobre o erro..."

where "update" is the job name, and 142965052 is the unique job run ID. Both variable.

Currently set only to 'update' (to notify in case of pip install errors, or push errors), and 'build-warn-as-err' to notify RST syntax errors. I didn't add to spellcheck and merge as I thought it wouldn't be necessary.

**NOTE:** It is required to set TELEGRAM_TO with the recipient ID (the group ID), and TELEGRAM_TOKEN with the sender ID (l17obot's, I assume) in the repository's secret variables.