### PR TITLE
workflow: use Python version 3.8

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -8,6 +8,7 @@ on:
 # Branch where translation takes place
 env:
   BRANCH: 3.9
+  PYTHON_VERSION: 3.8
 
 jobs:
 
@@ -22,6 +23,8 @@ jobs:
       with:
         ref: ${{ env.BRANCH }}
     - uses: actions/setup-python@v2
+      with:
+        python-version: ${{ env.PYTHON_VERSION }}
     - run: sudo apt update
     - run: sudo apt install -y gettext
     - run: make tx-config
@@ -67,6 +70,8 @@ jobs:
       with:
         ref: ${{ env.BRANCH }}
     - uses: actions/setup-python@v2
+      with:
+        python-version: ${{ env.PYTHON_VERSION }}
     - run: sudo apt update
     - run: sudo apt install -y gettext hunspell hunspell-pt-br
     - name: Run make spell
@@ -90,6 +95,8 @@ jobs:
       with:
         ref: ${{ env.BRANCH }}
     - uses: actions/setup-python@v2
+      with:
+        python-version: ${{ env.PYTHON_VERSION }}
     - run: pip install translate-toolkit powrap
     - run: sudo apt update
     - run: sudo apt install -y gettext
@@ -115,6 +122,8 @@ jobs:
         ref: ${{ env.BRANCH }}
     - run: git fetch --no-tags --prune --depth=1 origin +refs/heads/*:refs/remotes/origin/*
     - uses: actions/setup-python@v2
+      with:
+        python-version: ${{ env.PYTHON_VERSION }}
     - run: sudo apt update
     - run: sudo apt install -y gettext
     - name: Run make push
@@ -137,6 +146,8 @@ jobs:
       with:
         ref: ${{ env.BRANCH }}
     - uses: actions/setup-python@v2
+      with:
+        python-version: ${{ env.PYTHON_VERSION }}
     - run: make build CPYTHON_PATH=/tmp/cpython/ 2> >(tee -a build-log.txt >&2)
     - name: Update artifact build-output
       if: ${{ failure() }}


### PR DESCRIPTION
transifex-client is currently not compatible with 3.9. This was
explicitely set in its PyPI packages since 0.13.0, so using
Python 3.9 will result in being falling back to transifex-client
0.12.5, which doesn't have the --parallel flag.

By setting Python to 3.8, we work around this issue.