### PR TITLE
fix: Correction of the word "Discontinue"

### DIFF
--- a/whatsnew/3.10.po
+++ b/whatsnew/3.10.po
@@ -154,7 +154,7 @@ msgid ""
 ":pep:`623`, Deprecate and prepare for the removal of the wstr member in "
 "PyUnicodeObject."
 msgstr ""
-":pep:`623`, Desctinua e prepara para a remoção do membro wstr em "
+":pep:`623`, Descontinua e prepara para a remoção do membro wstr em "
 "PyUnicodeObject."
 
 #: ../../whatsnew/3.10.rst:95


### PR DESCRIPTION
Correction was made of the incorrect translation of the word "Desctinua" to "Descontinua"