### PR TITLE
Revamp our CI solution

### DIFF
--- a/.github/problem-matchers/sphinx.json
+++ b/.github/problem-matchers/sphinx.json
@@ -1,0 +1,40 @@
+{
+    "problemMatcher": [
+        {
+            "owner": "sphinx-problem-matcher",
+            "pattern": [
+                {
+                    "regexp": "^(.*):(\\d+):\\s+(\\w*):\\s+(.*)$",
+                    "file": 1,
+                    "line": 2,
+                    "severity": 3,
+                    "message": 4
+                }
+            ]
+        },
+        {
+            "owner": "sphinx-problem-matcher-loose",
+            "pattern": [
+                {
+                    "_comment": "A bit of a looser pattern, doesn't look for line numbers, just looks for file names relying on them to start with / and end with .rst",
+                    "regexp": "(\/.*\\.rst):\\s+(\\w*):\\s+(.*)$",
+                    "file": 1,
+                    "severity": 2,
+                    "message": 3
+                }
+            ]
+        },
+        {
+            "owner": "sphinx-problem-matcher-loose-no-severity",
+            "pattern": [
+                {
+                    "_comment": "Looks for file names ending with .rst and line numbers but without severity",
+                    "regexp": "^(.*\\.rst):(\\d+):(.*)$",
+                    "file": 1,
+                    "line": 2,
+                    "message": 3
+                }
+            ]
+        }
+    ]
+}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,93 @@
+# Build translated docs and notify in case of errors
+
+name: Build
+
+on:
+  workflow_dispatch:
+  workflow_call:
+    inputs:
+      was-called:
+        required: true
+        type: string
+        default: 'no'
+    secrets:
+      TELEGRAM_TO:
+        required: true
+      TELEGRAM_TOKEN:
+        required: true
+  push:
+    paths:
+      - '.github/workflows/build.yml'
+      - 'scripts/build.sh'
+      - 'scripts/prepmsg.sh'
+      - '*.po'
+      - '**/*.po'
+
+env:
+  CPYTHON_BRANCH: '3.10'
+  LANGUAGE: 'pt_BR'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out ${{ github.repository }}
+        uses: actions/checkout@v2
+        with:
+          persist-credentials: false
+      - run: echo ${{ inputs.was-called }}
+      - if: ${{ inputs.was-called }} == 'yes'
+        run: |
+          git pull --rebase
+      - name: Check out CPython
+        uses: actions/checkout@v2
+        with:
+          repository: python/cpython
+          persist-credentials: false
+          ref: ${{ env.CPYTHON_BRANCH }}
+          path: cpython
+      - name: Set up Python 3.9
+        uses: actions/setup-python@v2
+        with:
+          python-version: '3.9'
+      - name: Install dependencies
+        run: |
+          sudo apt update -y && sudo apt install gettext -y
+          pip3 install --upgrade pip
+          pip3 install -r requirements.txt -r cpython/Doc/requirements.txt
+      - name: Build docs
+        run: |
+          mkdir logs
+          echo "::add-matcher::.github/problem-matchers/sphinx.json"
+          sh scripts/build.sh 2> >(tee -a logs/error.log >&2)
+        env:
+          LANGUAGE: ${{ env.LANGUAGE }}
+      - name: Prepare notification on error
+        if: failure()
+        run: |
+          sh scripts/prepmsg.sh logs/error.log logs/notify.log
+        env:
+          GITHUB_JOB: ${{ github.job }}
+          GITHUB_RUN_ID: ${{ github.run_id }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+      - name: Notify via Telegram on build errors if any
+        if: failure()
+        uses: appleboy/telegram-action@master
+        with:
+          to: ${{ secrets.TELEGRAM_TO }}
+          token: ${{ secrets.TELEGRAM_TOKEN }}
+          format: markdown
+          disable_web_page_preview: true
+          message_file: logs/notify.log
+      - name: Upload artifact - docs
+        if: always()
+        uses: actions/upload-artifact@v2
+        with:
+          name: docs
+          path: cpython/Doc/build/html
+      - name: Upload artifact - logs
+        if: always()
+        uses: actions/upload-artifact@v2
+        with:
+          name: build-logs
+          path: logs/

--- a/.github/workflows/compendium.yml
+++ b/.github/workflows/compendium.yml
@@ -1,0 +1,39 @@
+name: Generate compendium
+
+on:
+  workflow_dispatch:
+  workflow_call:
+  push:
+    paths:
+      - '.github/workflows/compendium.yml'
+      - '*.po'
+      - '**/*.po'
+
+jobs:
+  compendium:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out ${{ github.repository }}
+        uses: actions/checkout@v2
+        with:
+          persist-credentials: false
+      - if: github.event_name == 'workflow_call'
+        run: |
+          git pull --rebase
+      - name: Set up Python 3.9
+        uses: actions/setup-python@v2
+        with:
+          python-version: '3.9'
+      - name: Install dependencies
+        run: |
+          sudo apt update -y && sudo apt install gettext -y
+          pip3 install --upgrade pip
+          pip3 install translate-toolkit
+      - name: Generate compendium from PO files
+        run: |
+          pocompendium --correct compendium.po *.po **/*.po
+      - name: Upload artifact
+        uses: actions/upload-artifact@v2
+        with:
+          name: compendium
+          path: compendium.po

--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -1,0 +1,133 @@
+name: Update translations
+
+on:
+  workflow_dispatch:
+  push:
+    paths:
+      - '.github/workflows/update.yml'
+      - 'scripts/update.sh'
+    branches:
+      - '*'
+      - '*/*'
+      - '**'
+      - '!3.?'
+      - '!2.*'
+  schedule:
+    - cron: '0 23 * * *'
+
+env:
+  CPYTHON_BRANCH: '3.10'
+  LANGUAGE: 'pt_BR'
+
+jobs:
+  update:
+    # Job to pull translation from Transifex platform, and commit & push changes
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out ${{ github.repository }}
+        uses: actions/checkout@v2
+      - name: Check out CPython
+        uses: actions/checkout@v2
+        with:
+          repository: python/cpython
+          persist-credentials: false
+          ref: ${{ env.CPYTHON_BRANCH }}
+          path: cpython
+      - name: Set up Python 3.9
+        uses: actions/setup-python@v2
+        with:
+          python-version: '3.9'
+      - name: Install dependencies
+        run: |
+          sudo apt update -y && sudo apt install gettext -y
+          pip3 install --upgrade pip
+          pip3 install -r requirements.txt -r cpython/Doc/requirements.txt
+      - name: Update translations
+        run: |
+          sh scripts/update.sh
+        env:
+          TX_TOKEN: ${{ secrets.TX_TOKEN }}
+          LANGUAGE: ${{ env.LANGUAGE }}
+      - name: Wrap catalog message files
+        run: |
+          powrap --modified
+      - name: Commit and push changes
+        if: github.repository == 'python/python-docs-pt-br'
+        run: |
+          git config user.name github-actions
+          git config user.email github-actions@github.com
+          git status
+          git add -A
+          git diff-index --quiet HEAD || ( git commit -m "Update translations from Transifex" && git push )
+
+  merge:
+    # Merge translations previously updated into older branches to make sure
+    # older versions of Python Docs gets translated as well.
+    # 'overwrite=true' means strings previously translated will get overwritten;
+    # other branches will preserve translated strings, only filling in new
+    # translations.
+    name: merge into ${{ matrix.branch }}
+    needs: [update]
+    strategy:
+      matrix:
+        branch: [ 3.9, 3.8, 3.7, 3.6, 2.7 ]
+        include:
+          - branch: 3.9
+            overwrite: true
+    runs-on: ubuntu-latest
+    steps:
+      - name: Get current branch name
+        shell: bash
+        run:
+          echo "CURRENT_BRANCH=$(echo ${GITHUB_REF#refs/heads/} | tr / -)" >> $GITHUB_ENV
+      - name: Check out source branch (${{ env.CURRENT_BRANCH }})
+        uses: actions/checkout@v2
+        with:
+          path: ${{ env.CURRENT_BRANCH }}
+          persist-credentials: false
+      - name: Check out target branch (${{ matrix.branch }})
+        uses: actions/checkout@v2
+        with:
+          ref: ${{ matrix.branch }}
+          path: ${{ matrix.branch }}
+      - name: Install dependencies
+        run: |
+          sudo apt update -y && sudo apt install gettext -y
+          pip3 install pomerge powrap
+      - name: Merge overwriting on stable release branch
+        if: ${{ matrix.overwrite == true }}
+        run: |
+          pomerge --from ${{ env.CURRENT_BRANCH }}/**/*.po --to ${{ matrix.branch }}/**/*.po
+      - name: Merge without overwriting on EOL or security-fix release branch
+        if: ${{ matrix.overwrite != true }}
+        run: |
+          pomerge --no-overwrite --from ${{ env.CURRENT_BRANCH }}/**/*.po --to ${{ matrix.branch }}/**/*.po
+      - name: Wrap catalog message files
+        run: |
+          powrap --modified -C ${{ matrix.branch }}
+      - name: Commit and push changes
+        if: github.repository == 'python/python-docs-pt-br'
+        run: |
+          cd ${{ matrix.branch }}
+          git config user.name github-actions
+          git config user.email github-actions@github.com
+          git status
+          git add -A
+          git diff-index --quiet HEAD || ( git commit -m "Merge ${{ env.CURRENT_BRANCH }} into ${{ matrix.branch }}" && git push )
+
+  call-build:
+    # Call the build workflow after updating
+    name: call
+    needs: [update]
+    uses: python/python-docs-pt-br/.github/workflows/build.yml@3.10
+    with:
+      was-called: yes
+    secrets:
+      TELEGRAM_TO: ${{ secrets.TELEGRAM_TO }}
+      TELEGRAM_TOKEN: ${{ secrets.TELEGRAM_TOKEN }}
+
+  call-compendium:
+    # Call the compendium workflow after updating
+    name: call
+    needs: [update]
+    uses: python/python-docs-pt-br/.github/workflows/compendium.yml@3.10

--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -37,6 +37,10 @@ jobs:
         uses: actions/setup-python@v2
         with:
           python-version: '3.9'
+      - name: Install Transifex CLI
+        run: |
+          curl -o- https://raw.githubusercontent.com/transifex/cli/master/install.sh | bash
+          mv tx /usr/local/bin/tx
       - name: Install dependencies
         run: |
           sudo apt update -y && sudo apt install gettext -y

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 .tx/**/*.po
 venv/
 .pospell/
+cpython/

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
 transifex-client
 sphinx-intl
 powrap
-pospell
 pomerge

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
-transifex-client
 sphinx-intl
 powrap
 pomerge

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -1,0 +1,28 @@
+#!/bin/sh
+# Build translated version of Python Docs
+
+[ -n "$GITHUB_ACTIONS" ] && set -x
+set -e
+
+# Allow language being passed as 1st argument, defaults to pt_BR
+LANGUAGE=${1:-pt_BR}
+
+ROOTDIR="$(dirname $0)/.."
+
+cd ${ROOTDIR}
+
+test -f cpython/Doc/conf.py || ( echo Unable to find proper CPython Doc folder; exit 1; )
+
+pofiles=$(find . -maxdepth 2 -name '*.po' | sort -u)
+
+for po in ${pofiles}; do
+  install -Dm644 ${po} "cpython/Doc/locales/${LANGUAGE}/LC_MESSAGES/${po}"
+done
+
+sphinx-build -b html -d build/doctrees -q --keep-going -jauto -D locale_dirs=locales -D language=pt_BR -D gettext_compact=0 -D latex_engine=xelatex -D latex_elements.inputenc= -D latex_elements.fontenc= -W cpython/Doc cpython/Doc/build/html
+
+if [ -z "$GITHUB_ACTIONS" ]; then
+  echo "See file:/$(realpath ${ROOTDIR})/cpython/Doc/build/html/index.html"
+  echo "or serve it in http://localhost:8080 by running:"
+  echo "python3 cpython/Tools/scripts/serve.py cpython/Doc/build/html"
+fi

--- a/scripts/prepmsg.sh
+++ b/scripts/prepmsg.sh
@@ -1,0 +1,20 @@
+#!/bin/sh
+# Prepare message for Telegram notification
+set -ex
+
+[ $# -ne 2 ] && ( echo "Expected 1 input and 1 output files, got $#"; exit; )
+[ ! -f $1 ]  && ( echo "Input file $1 not found, skipping."; exit; )
+[ -z "${GITHUB_REPOSITORY}" ] && (echo "GITHUB_REPOSITORY is empty."; exit 1;)
+[ -z "${GITHUB_RUN_ID}" ] && (echo "GITHUB_RUN_ID is empty."; exit 1;)
+[ -z "${GITHUB_JOB}" ] && (echo "GITHUB_JOB is empty."; exit 1;)
+
+URL="https://github.com/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
+
+echo "❌ *${GITHUB_JOB}* (ID&nbsp;[${GITHUB_RUN_ID}]($URL)):" > $2
+echo "" >> $2
+grep 'cpython/Doc/.*WARNING:' $1 | \
+      sed 's|.*/cpython/Doc|Doc|' | \
+      uniq | \
+      sed 's|^|```\n|;s|$|\n```\n|' \
+      >> $2
+echo "" >> $2

--- a/scripts/update.sh
+++ b/scripts/update.sh
@@ -1,0 +1,34 @@
+#!/bin/sh
+# Pull catalog message files from Transifex
+
+[ -n "$GITHUB_ACTIONS" ] && set -x
+set -e
+
+# Allow language being passed as 1st argument, defaults to pt_BR
+LANGUAGE=${1:-pt_BR}
+
+ROOTDIR=$(dirname $0)/..
+
+cd ${ROOTDIR}
+
+test -f cpython/Doc/conf.py || ( echo Unable to find proper CPython Doc folder; exit 1; )
+
+# Create POT Files
+cd cpython/Doc
+sphinx-build -E -b gettext -D gettext_compact=0 -d build/.doctrees . locales/pot
+
+# Update CPython's .tx/config
+cd  locales
+sphinx-intl create-txconfig
+sphinx-intl update-txconfig-resources -p pot -d . --transifex-project-name python-newest
+
+# Update the translation project's .tx/config
+cd ../../.. 	    # back to $ROOTDIR
+mkdir -p .tx
+sed cpython/Doc/locales/.tx/config \
+  -e '/^source_file/d' \
+  -e 's|<lang>/LC_MESSAGES/||' \
+  -e "s|^file_filter|trans.${LANGUAGE}|" \
+  > .tx/config
+
+tx pull -l ${LANGUAGE} --use-git-timestamps --parallel

--- a/scripts/update.sh
+++ b/scripts/update.sh
@@ -31,4 +31,4 @@ sed cpython/Doc/locales/.tx/config \
   -e "s|^file_filter|trans.${LANGUAGE}|" \
   > .tx/config
 
-tx pull -l ${LANGUAGE} --use-git-timestamps --parallel
+tx pull --languages ${LANGUAGE} --translations --use-git-timestamps --parallel


### PR DESCRIPTION
This commit re-implements the CI solution for python-docs-pt-br improving several aspects over the previous solution.

## PREVIOUS SOLUTION

The previous solution had a Makefile coded with all operations, and a single workflow (pythonpackage.yml) that had used this Makefile. The problem with this implementation was:

 - The Makefile had operations that would never be used in the user command line, hence they did not have to be in a script for the CLI causing the script to be bloated
 - The Makefile syntax is not very east for everyone, while Shell script is more common.
 - The workflow was bloated with different tasks, hence making it impossible to best use the events the could trigger the jobs (update, build, etc.)
 - The workflow could not be triggered manually by the admin
 - The spellchecking output generated by the target in Makefile and the job in the workflow had to much noise making it hard to read, and no one cared about to.

Also, some workflow instructions could receive some improvements. For instance, the Telegram notification message just linked to the workflow run without any other useful information on the error report. Instead of requiring the user to go to a link, it is more efficient to provide the error message already.

fix #37

## NEW SOLUTION

The new CI solution drops the use of the Makefile and the single workflow file to implement a few shell scripts and workflow files.

It features the following workflows:
 - update: pull translations from Transifex, and push into the main branch and also previous branches
 - build: build translated docs and notify in case of errors
 - compendium: generate a PO compendium of all translated strings

The build workflow makes use of a problem matcher to annotate Sphinx errors, making them more visible.

The workflows use the following shell scripts:
 - build: call sphinx-build to build the documentation
 - prepmsg: prepare a message to notify in a Telegram target group
 - update: call POT update, tx pull and other update instructions

The update workflow is scheduled to run every night, and will call the build and compendium workflow -- so all actions are run on schedule event.

These workflows can also be run manually in the webUI by the repository admin thanks to workflow_dispatch event, which is useful e.g. in a hackathon/sprint/etc. where one wants to run the workflow more than one time (scheduled) a day.

The command for pulling translations from Transifex, `tx pull`, is called by update.sh without `--force` but with `--use-git-timestamps`. This allows us to make sure all translations are pulled correct, without the 40 minutes of forced download.

The build.sh can be run in the command-line interface. All it is required is to git clone [CPython repo](https://github.com/python/cpython) in the python-docs-pt-br root directory and to install the requirements from 'requirements.txt' and 'cpython/Doc/requirement.txt' files.

build.sh uses pt_BR language code by default, but can be used by another language teams by passing other languages. e.g. `build.sh fr`

## Settings needed in the repository

### New TX_TOKEN secret required

The previous workflow is using TRANSIFEX_APIKEY as the Transifex API token variable name. As per Transifex documentation, when TX_TOKEN it is not required to create configuration file, hence it is much simpler in CI environment to use TX_TOKEN than other custom names.

TX_TOKEN has to be created with in order to the update workflow to works correctly.

### Disable the previous workflow

The .github/workflows/pythonpackage.yml, named "Build and update documentation in the Actions page, is scheduled to run every night, just like the new CI solution. So, there's a conflict.

This workflow must be disabled. Please refer the GitHub docs on how to disable an workflow: https://docs.github.com/en/actions/managing-workflow-runs/disabling-and-enabling-a-workflow