### PR TITLE
Fix how check.yml assures an updated checkout

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -44,6 +44,7 @@ jobs:
           python-version: '3'
       
       - name: Make sure the repository is up to date
+        if: github.event_name != pull_request
         run: git pull --rebase
       
       - name: Build docs
@@ -102,6 +103,7 @@ jobs:
           python-version: '3'
       
       - name: Make sure the repository is up to date
+        if: github.event_name != pull_request
         run: git pull --rebase
       
       - name: Run sphinx-lint
@@ -151,6 +153,7 @@ jobs:
           python-version: '3'
       
       - name: Make sure the repository is up to date
+        if: github.event_name != pull_request
         run: git pull --rebase
       
       - name: Run pospell
@@ -181,6 +184,7 @@ jobs:
           python-version: '3'
       
       - name: Make sure the repository is up to date
+        if: github.event_name != pull_request
         run: git pull --rebase
       
       - name: Install dependencies

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -38,22 +38,14 @@ jobs:
         with:
           persist-credentials: false
       
-      - uses: xSAVIKx/artifact-exists-action@v0
-        id: "check_workflow_exists"
-        with:
-          name: 'translations'
-      
-      - name: Download PO files (if called)
-        if: "${{ steps.check_workflow_exists.outputs.exists }}"
-        uses: actions/download-artifact@v3.0.2
-        with:
-          name: translations
-      
       - name: Set up Python 3
         uses: actions/setup-python@v4.6.1
         with:
           python-version: '3'
-          
+      
+      - name: Make sure the repository is up to date
+        run: git pull --rebase
+      
       - name: Build docs
         continue-on-error: true
         id: build
@@ -104,22 +96,14 @@ jobs:
         with:
           persist-credentials: false
       
-      - uses: xSAVIKx/artifact-exists-action@v0
-        id: "check_workflow_exists"
-        with:
-          name: 'translations'
-      
-      - name: Download PO files (if called)
-        if: "${{ steps.check_workflow_exists.outputs.exists }}"
-        uses: actions/download-artifact@v3.0.2
-        with:
-          name: translations
-      
       - name: Set up Python 3
         uses: actions/setup-python@v4.6.1
         with:
           python-version: '3'
-          
+      
+      - name: Make sure the repository is up to date
+        run: git pull --rebase
+      
       - name: Run sphinx-lint
         continue-on-error: true
         id: lint
@@ -161,21 +145,13 @@ jobs:
         with:
           persist-credentials: false
       
-      - uses: xSAVIKx/artifact-exists-action@v0
-        id: "check_workflow_exists"
-        with:
-          name: 'translations'
-      
-      - name: Download PO files (if called)
-        if: "${{ steps.check_workflow_exists.outputs.exists }}"
-        uses: actions/download-artifact@v3.0.2
-        with:
-          name: translations
-      
       - name: Set up Python 3
         uses: actions/setup-python@v4.6.1
         with:
           python-version: '3'
+      
+      - name: Make sure the repository is up to date
+        run: git pull --rebase
       
       - name: Run pospell
         continue-on-error: true
@@ -198,23 +174,15 @@ jobs:
         uses: actions/checkout@v3.5.2
         with:
           persist-credentials: false
-          
-      - uses: xSAVIKx/artifact-exists-action@v0
-        id: "check_workflow_exists"
-        with:
-          name: 'translations'
-      
-      - name: Download PO files (if called)
-        if: "${{ steps.check_workflow_exists.outputs.exists }}"
-        uses: actions/download-artifact@v3.0.2
-        with:
-          name: translations
       
       - name: Set up Python 3
         uses: actions/setup-python@v4.6.1
         with:
           python-version: '3'
-          
+      
+      - name: Make sure the repository is up to date
+        run: git pull --rebase
+      
       - name: Install dependencies
         run: |
           sudo apt update -y && sudo apt install gettext -y

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -44,7 +44,7 @@ jobs:
           python-version: '3'
       
       - name: Make sure the repository is up to date
-        if: github.event_name != pull_request
+        if: github.event_name != 'pull_request'
         run: git pull --rebase
       
       - name: Build docs
@@ -103,7 +103,7 @@ jobs:
           python-version: '3'
       
       - name: Make sure the repository is up to date
-        if: github.event_name != pull_request
+        if: github.event_name != 'pull_request'
         run: git pull --rebase
       
       - name: Run sphinx-lint
@@ -153,7 +153,7 @@ jobs:
           python-version: '3'
       
       - name: Make sure the repository is up to date
-        if: github.event_name != pull_request
+        if: github.event_name != 'pull_request'
         run: git pull --rebase
       
       - name: Run pospell
@@ -184,7 +184,7 @@ jobs:
           python-version: '3'
       
       - name: Make sure the repository is up to date
-        if: github.event_name != pull_request
+        if: github.event_name != 'pull_request'
         run: git pull --rebase
       
       - name: Install dependencies

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -35,6 +35,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3.5.2
+        with:
+          fetch-depth: 5
       
       - name: Set up Python 3
         uses: actions/setup-python@v4.6.1
@@ -91,6 +93,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3.5.2
+        with:
+          fetch-depth: 5
       
       - name: Set up Python 3
         uses: actions/setup-python@v4.6.1
@@ -138,6 +142,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3.5.2
+        with:
+          fetch-depth: 5
       
       - name: Set up Python 3
         uses: actions/setup-python@v4.6.1
@@ -166,6 +172,8 @@ jobs:
     steps:
       - name: Check out ${{ github.repository }}
         uses: actions/checkout@v3.5.2
+        with:
+          fetch-depth: 5
       
       - name: Set up Python 3
         uses: actions/setup-python@v4.6.1

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -35,8 +35,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3.5.2
-        with:
-          persist-credentials: false
       
       - name: Set up Python 3
         uses: actions/setup-python@v4.6.1
@@ -93,8 +91,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3.5.2
-        with:
-          persist-credentials: false
       
       - name: Set up Python 3
         uses: actions/setup-python@v4.6.1
@@ -142,8 +138,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3.5.2
-        with:
-          persist-credentials: false
       
       - name: Set up Python 3
         uses: actions/setup-python@v4.6.1
@@ -172,8 +166,6 @@ jobs:
     steps:
       - name: Check out ${{ github.repository }}
         uses: actions/checkout@v3.5.2
-        with:
-          persist-credentials: false
       
       - name: Set up Python 3
         uses: actions/setup-python@v4.6.1

--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -225,7 +225,7 @@ jobs:
   # Call the check.yml workflow after updating to run some tests
   call-build:
     name: call
-    needs: pull
+    needs: push
     if: github.event_name != 'pull_request'
     uses: ./.github/workflows/check.yml
     secrets: inherit


### PR DESCRIPTION
Currently, update workflow calls check workflow upon pull finish. Then the check worfklow downloads an artifact containing the translation files. But this is causing some issues, which ultimately is broken is some scenario.

This simplifies the process by calling check workflow only upon push finish. Then in check workflow do a git pull, except on pull_request event trigger (because it fails in this scenario).