### PR TITLE
fix: file name 'logging.cong' to 'logging.conf'

### DIFF
--- a/howto/logging.po
+++ b/howto/logging.po
@@ -982,7 +982,7 @@ msgstr ""
 
 #: ../../howto/logging.rst:661
 msgid "Here is the logging.conf file:"
-msgstr "Aqui está o arquivo logging.cong:"
+msgstr "Aqui está o arquivo logging.conf:"
 
 #: ../../howto/logging.rst:693
 msgid ""


### PR DESCRIPTION
Reading the logging documentation on https://docs.python.org/pt-br/3/howto/logging.html , I notice the extension on filename `logging.cong` have a typo.

![Screenshot 2024-01-25 at 11 47 23](https://github.com/python/python-docs-pt-br/assets/16025055/f731e683-d15f-4cd7-8a95-175a7584196d)
