### PR TITLE
Drop lint parentheses search in old Python versions

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,6 @@
 potodo==0.21.3
 powrap==1.0.1
 sphinx-intl==2.2.0
-sphinx-lint==1.0.0
+# avoid unnecessary parentheses search in old Python Docs
+sphinx-lint==1.0.0; python_version >= 3.12
+sphinx-lint==0.9.1; python_version < 3.12

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,5 +2,5 @@ potodo==0.21.3
 powrap==1.0.1
 sphinx-intl==2.2.0
 # avoid unnecessary parentheses search in old Python Docs
-sphinx-lint==1.0.0; python_version >= 3.12
-sphinx-lint==0.9.1; python_version < 3.12
+sphinx-lint==1.0.0; python_version >= "3.12"
+sphinx-lint==0.9.1; python_version < "3.12"


### PR DESCRIPTION
CPython will not fix in Python 3.11 and older versions the occurrences of unnecessary parentheses reported as of sphinx-lint 1.0.0. So, let's avoid them