### PR TITLE
lint: Disable literal-block only on 3.12 or newer

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,4 @@
 potodo==0.21.3
 powrap==1.0.1
 sphinx-intl==2.2.0
-# avoid unnecessary parentheses search in old Python Docs
-sphinx-lint==1.0.0; python_version >= "3.12"
-sphinx-lint==0.9.1; python_version < "3.12"
+sphinx-lint==1.0.0

--- a/scripts/lint.sh
+++ b/scripts/lint.sh
@@ -22,11 +22,11 @@ cd cpython/Doc
 
 # If version is 3.12 or newer, then disable literal-block, generate POT and
 # update translations with fresh POT files. If version 3.11 or older,
-# disable new 'unnecessary-parentheses' check, not fix before these versions.
+# disable new 'unnecessary-parentheses' check, not fixed before these versions.
 minor_version=$(git branch --show-current | sed 's|^3\.||')
 if [ $minor_version -ge 12 ]; then
   sed -i "/^\s*'literal-block',/s/ '/ #'/" conf.py
-  make gettext
+  make gettext SPHINXOPTS='-q'
   sphinx-intl update -p build/gettext -l ${PYDOC_LANGUAGE} > /dev/null
 else
   alias sphinx-lint='sphinx-lint --disable unnecessary-parentheses'

--- a/scripts/lint.sh
+++ b/scripts/lint.sh
@@ -21,12 +21,15 @@ touch logs/sphinxlint.txt
 cd cpython/Doc
 
 # If version is 3.12 or newer, then disable literal-block, generate POT and
-# update translations with fresh POT files. 
+# update translations with fresh POT files. If version 3.11 or older,
+# disable new 'unnecessary-parentheses' check, not fix before these versions.
 minor_version=$(git branch --show-current | sed 's|^3\.||')
 if [ $minor_version -ge 12 ]; then
   sed -i "/^\s*'literal-block',/s/ '/ #'/" conf.py
   make gettext
   sphinx-intl update -p build/gettext -l ${PYDOC_LANGUAGE} > /dev/null
+else
+  alias sphinx-lint='sphinx-lint --disable unnecessary-parentheses'
 fi
 
 cd locales/${PYDOC_LANGUAGE}/LC_MESSAGES

--- a/scripts/lint.sh
+++ b/scripts/lint.sh
@@ -20,13 +20,14 @@ touch logs/sphinxlint.txt
 
 cd cpython/Doc
 
-# Disable literal blocks and update PO
-sed -i "/^\s*'literal-block',/s/ '/ #'/" conf.py
-# TODO: use `make -C .. gettext` when there are only Python >= 3.12
-opts='-E -b gettext -q -D gettext_compact=0 -d build/.doctrees . build/gettext' 
-make build ALLSPHINXOPTS="$opts"
-# Update translation files with latest POT
-sphinx-intl update -p build/gettext -l ${PYDOC_LANGUAGE} > /dev/null
+# If version is 3.12 or newer, then disable literal-block, generate POT and
+# update translations with fresh POT files. 
+minor_version=$(git branch --show-current | sed 's|^3\.||')
+if [ $minor_version -ge 12 ]; then
+  sed -i "/^\s*'literal-block',/s/ '/ #'/" conf.py
+  make gettext
+  sphinx-intl update -p build/gettext -l ${PYDOC_LANGUAGE} > /dev/null
+fi
 
 cd locales/${PYDOC_LANGUAGE}/LC_MESSAGES
 set +e


### PR DESCRIPTION
Avoid the very slow step of gettext builder and sphinx-intl update when not necessary (i.e. do not run on Python 3.11 and older)