### PR TITLE
ci: declare workflow-level `contents: read` on the 9 python-N.yml build workflows

### DIFF
--- a/.github/workflows/python-310.yml
+++ b/.github/workflows/python-310.yml
@@ -5,6 +5,9 @@ on:
   schedule:
     - cron: '15 0 * * *'
 
+permissions:
+  contents: read
+
 jobs:
   sync:
     uses: ./.github/workflows/sync.yml

--- a/.github/workflows/python-311.yml
+++ b/.github/workflows/python-311.yml
@@ -5,6 +5,9 @@ on:
   schedule:
     - cron: '0 0 * * *'
 
+permissions:
+  contents: read
+
 jobs:
   sync:
     uses: ./.github/workflows/sync.yml

--- a/.github/workflows/python-312.yml
+++ b/.github/workflows/python-312.yml
@@ -5,6 +5,9 @@ on:
   schedule:
     - cron: '45 23 * * *'
 
+permissions:
+  contents: read
+
 jobs:
   sync:
     uses: ./.github/workflows/sync.yml

--- a/.github/workflows/python-313.yml
+++ b/.github/workflows/python-313.yml
@@ -13,6 +13,9 @@ on:
       - main
       - '3.13'
 
+permissions:
+  contents: read
+
 jobs:
   sync:
     uses: ./.github/workflows/sync.yml

--- a/.github/workflows/python-314.yml
+++ b/.github/workflows/python-314.yml
@@ -13,6 +13,9 @@ on:
       - main
       - '3.14'
 
+permissions:
+  contents: read
+
 jobs:
   sync:
     uses: ./.github/workflows/sync.yml

--- a/.github/workflows/python-315.yml
+++ b/.github/workflows/python-315.yml
@@ -13,6 +13,9 @@ on:
       - main
       - '3.15'
 
+permissions:
+  contents: read
+
 jobs:
   sync:
     uses: ./.github/workflows/sync.yml

--- a/.github/workflows/python-37.yml
+++ b/.github/workflows/python-37.yml
@@ -3,6 +3,9 @@ name: python-37
 on:
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   sync:
     uses: ./.github/workflows/sync.yml

--- a/.github/workflows/python-38.yml
+++ b/.github/workflows/python-38.yml
@@ -3,6 +3,9 @@ name: python-38
 on:
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   sync:
     uses: ./.github/workflows/sync.yml

--- a/.github/workflows/python-39.yml
+++ b/.github/workflows/python-39.yml
@@ -3,6 +3,9 @@ name: python-39
 on:
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   sync:
     uses: ./.github/workflows/sync.yml


### PR DESCRIPTION
Pins the default `GITHUB_TOKEN` to `contents: read` on the per-Python-version build workflows: `python-37.yml` through `python-315.yml`. Each runs sphinx-build against the translated rst files and uploads the rendered HTML as a workflow artifact, with no GitHub API mutation.

## Why

CVE-2025-30066 (March 2025 `tj-actions/changed-files` supply-chain compromise) exfiltrated `GITHUB_TOKEN` from workflow logs and the leaked token retained whatever scope was issued at the workflow level. Pinning per workflow caps that runtime authority irrespective of the repo or org default, gives drift protection if the default ever widens, and is credited per-file by the OpenSSF Scorecard `Token-Permissions` check.

YAML validated locally with `yaml.safe_load` on each touched file.