### PR TITLE
docs(pt-br): traduzir entradas pendentes em asyncio-queue e c-api/dict

### DIFF
--- a/c-api/dict.po
+++ b/c-api/dict.po
@@ -125,6 +125,10 @@ msgid ""
 "on success or ``-1`` on failure. This function *does not* \":term:`steal`\" "
 "a reference to *val*."
 msgstr ""
+"Insere *val* no dicionário *p* com a chave *key*. *key* deve ser :"
+"term:`hasheável <hashable>`; se não for, :exc:`TypeError` será levantada. Retorna ``0`` "
+"em caso de sucesso ou ``-1`` em caso de falha. Esta função *não* \":term:`furta`\" "
+"uma referência para *val*."
 
 #: ../../c-api/dict.rst:93
 msgid ""
@@ -183,6 +187,7 @@ msgstr ""
 msgid ""
 "On error, raise an exception, set *\\*result* to ``NULL`` and return ``-1``."
 msgstr ""
+"Em caso de erro, levanta uma exceção, define *\\*result* como ``NULL`` e retorna ``-1``."
 
 #: ../../c-api/dict.rst:125
 msgid "See also the :c:func:`PyObject_GetItem` function."

--- a/library/asyncio-queue.po
+++ b/library/asyncio-queue.po
@@ -139,6 +139,7 @@ msgstr ""
 msgid ""
 "Raises :exc:`QueueShutDown` if the queue has been shut down and is empty."
 msgstr ""
+"Levanta :exc:`QueueShutDown` se a fila foi encerrada e está vazia."
 
 #: ../../library/asyncio-queue.rst:79
 msgid "Block until all items in the queue have been received and processed."
@@ -195,6 +196,10 @@ msgid ""
 "`QueueShutDown`. Currently blocked callers of :meth:`~Queue.put` will be "
 "unblocked and will raise :exc:`QueueShutDown` in the formerly awaiting task."
 msgstr ""
+"A fila não pode mais crescer. Chamadas futuras a :meth:`~Queue.put` levantam "
+":exc:`QueueShutDown`. Chamadores de :meth:`~Queue.put` atualmente bloqueados "
+"serão desbloqueados e levantarão :exc:`QueueShutDown` na tarefa que estava "
+"aguardando anteriormente."
 
 #: ../../library/asyncio-queue.rst:116
 msgid ""


### PR DESCRIPTION
### Descrição
Tradução de entradas pendentes em português brasileiro (pt-BR) para a documentação do Python 3.13:
- `library/asyncio-queue.po`: Tradução das descrições de comportamento de `QueueShutDown` ao enfileirar em filas fechadas ou vazias.
- `c-api/dict.po`: Tradução das descrições de `PyDict_SetItem` e `PyDict_GetItemRef`.