### PR TITLE
Enhance artifact upload/download in sync workflow

### DIFF
--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -118,11 +118,13 @@ jobs:
         with:
           name: python-${{ env.PYDOC_VERSION }}
           path: |
-            .tx/config
-            potodo.md
-            stats.json
-            *.po
-            **/*.po
+            ./${PYDOC_LANG_DIR}/.tx/config
+            ./${PYDOC_LANG_DIR}/potodo.md
+            ./${PYDOC_LANG_DIR}/stats.json
+            ./${PYDOC_LANG_DIR}/*.po
+            ./${PYDOC_LANG_DIR}/**/*.po
+        env:
+          PYDOC_LANG_DIR: ${{ env.PYDOC_LANG_DIR }}
 
   commit:
     runs-on: ubuntu-latest

--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -118,11 +118,11 @@ jobs:
         with:
           name: python-${{ env.PYDOC_VERSION }}
           path: |
-            ./${PYDOC_LANG_DIR}/.tx/config
-            ./${PYDOC_LANG_DIR}/potodo.md
-            ./${PYDOC_LANG_DIR}/stats.json
-            ./${PYDOC_LANG_DIR}/*.po
-            ./${PYDOC_LANG_DIR}/**/*.po
+            ${PYDOC_LANG_DIR}/.tx/config
+            ${PYDOC_LANG_DIR}/potodo.md
+            ${PYDOC_LANG_DIR}/stats.json
+            ${PYDOC_LANG_DIR}/*.po
+            ${PYDOC_LANG_DIR}/**/*.po
         env:
           PYDOC_LANG_DIR: ${{ env.PYDOC_LANG_DIR }}
 

--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -117,6 +117,8 @@ jobs:
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         with:
           name: python-${{ env.PYDOC_VERSION }}
+          include-hidden-files: true
+          if-no-files-found: error
           path: |
             ${{ env.PYDOC_LANG_DIR }}/.tx/config
             ${{ env.PYDOC_LANG_DIR }}/potodo.md
@@ -165,6 +167,7 @@ jobs:
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: python-${{ env.PYDOC_VERSION }}
+          path: ${{ env.PYDOC_LANG_DIR }}
 
       # 3- Commit and push changed files depending on the event name
 

--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -118,13 +118,11 @@ jobs:
         with:
           name: python-${{ env.PYDOC_VERSION }}
           path: |
-            ${PYDOC_LANG_DIR}/.tx/config
-            ${PYDOC_LANG_DIR}/potodo.md
-            ${PYDOC_LANG_DIR}/stats.json
-            ${PYDOC_LANG_DIR}/*.po
-            ${PYDOC_LANG_DIR}/**/*.po
-        env:
-          PYDOC_LANG_DIR: ${{ env.PYDOC_LANG_DIR }}
+            ${{ env.PYDOC_LANG_DIR }}/.tx/config
+            ${{ env.PYDOC_LANG_DIR }}/potodo.md
+            ${{ env.PYDOC_LANG_DIR }}/stats.json
+            ${{ env.PYDOC_LANG_DIR }}/*.po
+            ${{ env.PYDOC_LANG_DIR }}/**/*.po
 
   commit:
     runs-on: ubuntu-latest


### PR DESCRIPTION
potodo,md and stats.json were not being updated in the current CI, and that's unintentional.  When splitting commit job from sync (translations pull) job, upload-artifact and download-artifact GitHub actions were incorrectly configured:
- upload-artifact action by default warns when no input file is found, and but we want to it to be an error (that shouldn't happen in our scenario).
- upload-artifact action doesn't include hidden files by default, and we need to include the file from hidden directory `.tx/config`
- upload-artifact action's input files had incorrect path: they are stored inside $PYDOC_LANG_DIR, not in the $GITHUB_WORKSPACE, so the path needed to be specified.
- upload-artifact doesn't keep $PYDOC_LANG_DIR when compressing the input fies, which means in download-artifact needs a 'path' value to be specified in order to extract to the correct directory.